### PR TITLE
Small Refactoring for Build-CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,22 @@ jobs:
           release-tag: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  invoke_package_distribution:
+    name: Invoke chipmunk package creation and distribution for different package managers
+    needs: build_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout chipmunk-distribution
+        uses: actions/checkout@v2
+        with:
+          repository: esrlabs/chipmunk-distribution
+          path: './chipmunk-distribution'
+          token: ${{secrets.PUSH_TOKEN}}
+      - name: Push tag
+        working-directory: ./chipmunk-distribution
+        run: |
+          git config user.name "esrlabs"
+          git config user.email "esrlabs@gmail.com"
+          git remote set-url origin "https://esrlabs:${{secrets.PUSH_TOKEN}}@github.com/esrlabs/chipmunk-distribution"
+          git tag ${{ github.ref_name }}
+          git push origin ${{ github.ref_name }}

--- a/cli/src/fstools.rs
+++ b/cli/src/fstools.rs
@@ -11,11 +11,7 @@ pub async fn cp_file(src: PathBuf, dest: PathBuf) -> Result<(), Error> {
     TRACKER
         .success(
             sequence,
-            &format!(
-                "copied: {} to {}",
-                src.to_string_lossy(),
-                dest.to_string_lossy()
-            ),
+            &format!("copied: {} to {}", src.display(), dest.display()),
         )
         .await;
     Ok(())
@@ -25,11 +21,7 @@ pub async fn cp_folder(src: PathBuf, dest: PathBuf) -> Result<(), Error> {
     let sequence = TRACKER.start("copy folder", None).await?;
     let options = CopyOptions::new();
     let (tx, rx): (mpsc::Sender<TransitProcess>, mpsc::Receiver<TransitProcess>) = mpsc::channel();
-    let msg = format!(
-        "copied: {} to {}",
-        src.to_string_lossy(),
-        dest.to_string_lossy()
-    );
+    let msg = format!("copied: {} to {}", src.display(), dest.display());
     spawn(async move {
         if let Err(e) = copy_with_progress(src, dest, &options, |info| {
             if tx.send(info).is_err() {
@@ -64,7 +56,7 @@ pub async fn rm_folder(path: PathBuf) -> Result<(), Error> {
     let sequence = TRACKER.start("remove folder", None).await?;
     fs::remove_dir_all(&path)?;
     TRACKER
-        .success(sequence, &format!("removed: {}", path.to_string_lossy(),))
+        .success(sequence, &format!("removed: {}", path.display(),))
         .await;
     Ok(())
 }

--- a/cli/src/location.rs
+++ b/cli/src/location.rs
@@ -1,5 +1,6 @@
 use crate::LOCATION;
 use std::ffi::OsStr;
+use std::path::Path;
 use std::{
     env::current_dir,
     io::{Error, ErrorKind},
@@ -35,7 +36,6 @@ impl Location {
     }
 }
 
-pub fn to_relative_path(path: PathBuf) -> String {
-    let path_str = path.to_string_lossy().to_string();
-    path_str.replace(&LOCATION.root.to_string_lossy().to_string(), "")
+pub fn to_relative_path(path: &PathBuf) -> &Path {
+    path.strip_prefix(&LOCATION.root).unwrap_or(path)
 }

--- a/cli/src/location.rs
+++ b/cli/src/location.rs
@@ -1,5 +1,4 @@
 use crate::LOCATION;
-use std::ffi::OsStr;
 use std::path::Path;
 use std::{
     env::current_dir,
@@ -15,23 +14,16 @@ pub struct Location {
 impl Location {
     pub fn new() -> Result<Location, Error> {
         let mut root = current_dir()?;
-        let mut len = root.iter().collect::<Vec<&OsStr>>().len();
-        loop {
-            if len == 0 {
+        // TODO: better compare folders stucts or some file, like some git config file
+        while !root.ends_with("chipmunk") && !root.ends_with("logviewer") {
+            if !root.pop() {
                 return Err(Error::new(
                     ErrorKind::NotFound,
                     "Fail to find project's root location",
                 ));
             }
-            // TODO: better compare folders stucts or some file, like some git config file
-            if root.ends_with("chipmunk") || root.ends_with("logviewer") {
-                break;
-            }
-            if len > 0 {
-                len = len.saturating_sub(1);
-            }
-            root.pop();
         }
+
         Ok(Self { root })
     }
 }

--- a/cli/src/modules/app.rs
+++ b/cli/src/modules/app.rs
@@ -42,7 +42,7 @@ impl Manager for Module {
         if !src.exists() {
             return Err(Error::new(
                 ErrorKind::NotFound,
-                format!("Not found: {}", src.to_string_lossy()),
+                format!("Not found: {}", src.display()),
             ));
         }
         if !dest.exists() {

--- a/cli/src/modules/binding.rs
+++ b/cli/src/modules/binding.rs
@@ -29,9 +29,13 @@ impl Manager for Module {
         vec![]
     }
     fn build_cmd(&self, prod: bool) -> Option<String> {
+        let path = Target::Wrapper
+            .get()
+            .cwd()
+            .join("node_modules/.bin/electron-build-env");
         Some(format!(
-            "/{}/node_modules/.bin/electron-build-env nj-cli build{}",
-            Target::Wrapper.get().cwd().to_string_lossy(),
+            "{} nj-cli build{}",
+            path.to_string_lossy(),
             if prod { " --release" } else { "" }
         ))
     }

--- a/cli/src/spawner.rs
+++ b/cli/src/spawner.rs
@@ -59,7 +59,10 @@ pub async fn spawn(
         cmd
     };
     let sequence = TRACKER
-        .start(&format!("{}: {}", to_relative_path(cwd), job_title), None)
+        .start(
+            &format!("{}: {}", to_relative_path(&cwd).display(), job_title),
+            None,
+        )
         .await?;
     let mut stdout_lines: Vec<String> = vec![];
     let drain_stdout = {

--- a/contribution.md
+++ b/contribution.md
@@ -77,31 +77,33 @@ As mentioned earlier backend is built in Rust which takes care of reading the lo
 and frontend app is built using Electron JS.
 
 When you are running application first time on your local it is good idea to clean everything
-and build the new application.
+and build and start the new application in the development configuration.
 
+```bash
+rake clean
+rake build_dev
+rake run_dev
 ```
-rake developing:clean_rebuild_all
-yarn start electron
-```
+Which will open Chipmunk user interface, Yay!
 
-which will open Chipmunk user interface, Yay!
+To build and start the app in the production configuration you can use
+
+```bash
+rake clean
+rake build_prod
+rake run_prod
+```
 
 Most of the day-to-day task are written using Rake from Ruby. You can list all the tasks by
 
 ```
 rake -T
-# or
-rake # => Opens interactive shell
 ```
 
-### Changes made in Rust backend
-Everytime you change the Rust code you have to compile the binary and
-then start the application using NodeJS script.
+It's recommended to rebuild the app incrementally and run the app after changes using 
 
-```
-cd application/holder
-rake developing:holder_bindings
-yarn start electron
+```bash
+rake run_dev  #or rake run_prod for production configuration
 ```
 
 ### Changes in ElectronJS code
@@ -115,14 +117,7 @@ yarn run electron
 ### Changes in Frontend part
 ```
 cd application/holder
-rake build:client_dev
-yarn run electron
-```
-
-### Changes in both backend and frontend
-```
-cd application/holder
-rake developing:holder_platform_bindings
+rake client:build_dev   #or rake client:build_prod for production configuration
 yarn run electron
 ```
 
@@ -131,9 +126,20 @@ With this you can take a look at the open issues and open a PR to fix them.
 ## Creating your first PR
 Before opening up the PR please fork the repo and check for code smells or any issues using
 
-```
+```bash
 rake lint:all
-rake clippy:all
+```
+
+To run linting for the backend only you can use
+
+```bash
+rake lint:rust
+```
+
+To run linting for the frontend only you can use
+
+```bash
+rake lint:js
 ```
 
 Make sure your changes are covered by valid test cases and check if all test cases are passing

--- a/scripts/elements/client.rb
+++ b/scripts/elements/client.rb
@@ -45,12 +45,7 @@ namespace :client do
     'wasm:build',
     'environment:check'
   ] do
-    client_build_needed = ChangeChecker.changes?('client_release', Paths::CLIENT)
-    if client_build_needed
-      execute_client_build(:production)
-    else
-      Reporter.skipped('client_release', 'build in production mode', '')
-    end
+    execute_client_build(:production)
   end
 
   desc 'Build client (dev)'
@@ -58,12 +53,7 @@ namespace :client do
     'client:install',
     'wasm:build'
   ] do
-    client_build_needed = ChangeChecker.changes?('client_debug', Paths::CLIENT)
-    if client_build_needed
-      execute_client_build(:debug)
-    else
-      Reporter.skipped('client_debug', 'build in debug mode', '')
-    end
+    execute_client_build(:debug)
   end
 
   desc 'Lint client'

--- a/scripts/elements/platform.rb
+++ b/scripts/elements/platform.rb
@@ -6,6 +6,23 @@ module Platform
   TARGETS = [DIST, NODE_MODULES].freeze
 end
 
+def check_if_files_are_updated(path_in_platform)
+  require 'digest'
+  require 'find'
+  path_to_check = "#{Paths::PLATFORM}/#{path_in_platform}"
+  reference_checksum = Digest::MD5.file(path_to_check).hexdigest
+  root_p = Pathname.new(Paths::ROOT)
+  puts "compare with reference : #{Pathname.new(path_to_check).relative_path_from(root_p)}"
+  Find.find("#{Paths::ROOT}/application") do |path|
+    if path =~ /request\/file\/checksum.ts/
+      p = Pathname.new(path)
+      p_rel = p.relative_path_from(root_p)
+      checksum = Digest::MD5.file(path).hexdigest
+      puts "path: #{p_rel}: #{checksum == reference_checksum ? 'OK' : 'OUT OF SYNC!'}"
+    end
+  end
+end
+
 namespace :platform do
   desc 'check if copied files are synced'
   task :check_sync do
@@ -17,6 +34,30 @@ namespace :platform do
     puts "compare with reference : #{Pathname.new(path_to_check).relative_path_from(root_p)}"
     Find.find("#{Paths::ROOT}/application") do |path|
       if path =~ /request\/file\/checksum.ts/
+        p = Pathname.new(path)
+        p_rel = p.relative_path_from(root_p)
+        checksum = Digest::MD5.file(path).hexdigest
+        puts "path: #{p_rel}: #{checksum == reference_checksum ? 'OK' : 'OUT OF SYNC!'}"
+      end
+    end
+
+    path_to_check = "#{Paths::ROOT}/application/platform/modules/system.ts"
+    reference_checksum = Digest::MD5.file(path_to_check).hexdigest
+    puts "compare with reference : #{Pathname.new(path_to_check).relative_path_from(root_p)}"
+    Find.find("#{Paths::ROOT}") do |path|
+      if path =~ /platform\/modules\/system.ts/
+        p = Pathname.new(path)
+        p_rel = p.relative_path_from(root_p)
+        checksum = Digest::MD5.file(path).hexdigest
+        puts "path: #{p_rel}: #{checksum == reference_checksum ? 'OK' : 'OUT OF SYNC!'}"
+      end
+    end
+
+    path_to_check = "#{Paths::ROOT}/application/platform/dist/modules/system.js"
+    reference_checksum = Digest::MD5.file(path_to_check).hexdigest
+    puts "compare with reference : #{Pathname.new(path_to_check).relative_path_from(root_p)}"
+    Find.find("#{Paths::ROOT}") do |path|
+      if path =~ /dist\.*\/system.js/
         p = Pathname.new(path)
         p_rel = p.relative_path_from(root_p)
         checksum = Digest::MD5.file(path).hexdigest


### PR DESCRIPTION
This PR provides small refactoring and rewrite for some function to make them more idiomatic rust.

Changes:
- Replace `to_string_lossy()` with `display()` when printing paths to the users
- Rewrite `to_relative_path()` using built-in PathBuf methods instead string manipulations
- Rewrite finding root method in more idiomatic way
- Refactoring in `Binding::build_cmd()` method to use PathBuf method.