### PR TITLE
Build-CLI: Refactoring & Suggestions for Tracker UI

### DIFF
--- a/cli/src/tracker.rs
+++ b/cli/src/tracker.rs
@@ -70,9 +70,8 @@ impl Tracker {
                         bars.insert(sequence, (bar, Instant::now(), job, None));
                         bars.iter_mut().for_each(|(k, (bar, _, job, result))| {
                             bar.set_prefix(format!(
-                                "[{:0seq_width$}/{:0seq_width$}][{}][{job}]",
+                                "[{:seq_width$}/{sequence_txt}][{}][{job}]",
                                 k,
-                                sequence_txt,
                                 result
                                     .as_ref()
                                     .map_or_else(|| String::from("...."), |res| res.to_string()),
@@ -101,9 +100,8 @@ impl Tracker {
                         if let Some((bar, instant, job, res)) = bars.get_mut(&seq) {
                             let sequence_txt = sequence.to_string();
                             bar.set_prefix(format!(
-                                "[{:0seq_width$}/{:0seq_width$}][{}][{job}]",
+                                "[{:seq_width$}/{sequence_txt}][{}][{job}]",
                                 seq,
-                                sequence_txt,
                                 result,
                                 seq_width = sequence_txt.len()
                             ));


### PR DESCRIPTION
This PR still a work in progress, since it has some suggestions that I would like to discuss... 

**Implemented Points:**
- [x] Rewrite jobs alignment to keep the braces and the symbols in the same horizontal alignment among all lines.
- [x] Little refactoring to write the progress line in one print call. 
- [x] Small refactoring to get the length or max using  `unwrap_or`.
- [ ] Use progress bar as working indicator.

**Suggestion:**
I think if we used the status bar as working indicator that moves up and down while the job is in progress would give a more responsive look to the app. I can implement that using a timer and the `select!` macro in inside the `run()` method of the `tracker` struct.

@DmitryAstafyev Do you think it would be better to keep an indicator moving while the job is in progress or it's better to keep the bar as progress bar?