### PR TITLE
Implementation for wasm bindings

### DIFF
--- a/cli/src/modules/mod.rs
+++ b/cli/src/modules/mod.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod client;
 pub mod core;
 pub mod shared;
+pub mod wasm;
 pub mod wrapper;
 
 use crate::{

--- a/cli/src/modules/wasm.rs
+++ b/cli/src/modules/wasm.rs
@@ -1,0 +1,40 @@
+use super::{Kind, Manager};
+use crate::{Target, LOCATION};
+use async_trait::async_trait;
+use std::path::PathBuf;
+
+const PATH: &str = "application/apps/rustcore/wasm-bindings";
+
+#[derive(Clone, Debug)]
+pub struct Module {}
+
+impl Module {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl Manager for Module {
+    fn owner(&self) -> Target {
+        Target::Wasm
+    }
+    fn kind(&self) -> Kind {
+        Kind::Rs
+    }
+    fn cwd(&self) -> PathBuf {
+        LOCATION.root.clone().join(PATH)
+    }
+
+    fn deps(&self) -> Vec<Target> {
+        //TODO: Do we have dependencies here?
+        vec![]
+    }
+    fn build_cmd(&self, prod: bool) -> Option<String> {
+        //TODO: It's possible to set the environment with wasm-pack, but it wasn't set in the ruby
+        //version. Check if we can set it here.
+        let env = if prod { "--release" } else { "--dev" };
+
+        Some(format!("wasm-pack build {env} --target bundler"))
+    }
+}

--- a/cli/src/modules/wasm.rs
+++ b/cli/src/modules/wasm.rs
@@ -1,7 +1,11 @@
 use super::{Kind, Manager};
-use crate::{Target, LOCATION};
+use crate::{
+    spawner::{spawn, SpawnResult},
+    Target, LOCATION,
+};
 use async_trait::async_trait;
-use std::path::PathBuf;
+use futures::future::join_all;
+use std::{io, path::PathBuf};
 
 const PATH: &str = "application/apps/rustcore/wasm-bindings";
 
@@ -36,5 +40,23 @@ impl Manager for Module {
         let env = if prod { "--release" } else { "--dev" };
 
         Some(format!("wasm-pack build {env} --target bundler"))
+    }
+}
+
+impl Module {
+    // TODO: Use this implementation when testing is implemented in the system
+    #[allow(dead_code)]
+    pub async fn run_tests(&self) -> Vec<Result<SpawnResult, io::Error>> {
+        let path_karma = self.cwd().join("spec");
+
+        join_all([
+            spawn(
+                "wasm-pack test --node",
+                Some(self.cwd()),
+                Some("wasm-pack test wasm-bindings"),
+            ),
+            spawn("npm run test", Some(path_karma), Some("npm test wasm")),
+        ])
+        .await
     }
 }

--- a/cli/src/target.rs
+++ b/cli/src/target.rs
@@ -42,6 +42,7 @@ impl Target {
             Box::new(modules::wrapper::Module::new()),
             Box::new(modules::shared::Module::new()),
             Box::new(modules::client::Module::new()),
+            Box::new(modules::wasm::Module::new()),
         ]
     }
     pub fn get(&self) -> Box<dyn Manager + Sync + Send> {

--- a/cli/src/target.rs
+++ b/cli/src/target.rs
@@ -10,6 +10,7 @@ pub enum Target {
     Shared,
     App,
     Cli,
+    Wasm,
 }
 
 impl std::fmt::Display for Target {
@@ -25,6 +26,7 @@ impl std::fmt::Display for Target {
                 Target::Client => "Client",
                 Target::Shared => "Shared",
                 Target::App => "App",
+                Target::Wasm => "Wasm",
             }
         )
     }
@@ -51,6 +53,7 @@ impl Target {
             Target::Wrapper => Box::new(modules::wrapper::Module::new()),
             Target::Shared => Box::new(modules::shared::Module::new()),
             Target::App => Box::new(modules::app::Module::new()),
+            Target::Wasm => Box::new(modules::wasm::Module::new()),
         }
     }
 }


### PR DESCRIPTION
This PR provides the implementation for wasm bindings into the CLI app. It provides the needed implementation to run building, cleaning, linting and testing for wasm tasks the part under the path `application/apps/rustcore/wasm-bindings`

There are some points that need to be clarify though. I've written TODOs in the source code and I'll list them here too...
- I couldn't find any dependencies for building wasm bindings in ruby file, but I'm still not sure if we need to add dependencies to the implementation of the method `deps()` in the trait `Manager`
- I've found different flags for develop and release in the documentation of wasm-pack, and I built them in the new system, but they were not implemented in the ruby version. Therefore I'm not sure if we need them there or if you can stay with the old implementation
- I've implemented a prototype to run the tests for wasm module, which we can use once running the tests is built in the CLI app 

I'll mark this as draft until we clarify these points...